### PR TITLE
Wrap curl errors in a more specific exception

### DIFF
--- a/src/Error/CurlError.php
+++ b/src/Error/CurlError.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Ergo\Http\Error;
+
+use Ergo\Http\Error;
+
+class CurlError extends Error
+{
+    public function __construct($string)
+    {
+        parent::__construct($string);
+    }
+}

--- a/src/Transport.php
+++ b/src/Transport.php
@@ -2,6 +2,8 @@
 
 namespace Ergo\Http;
 
+use Ergo\Http\Error\CurlError;
+
 class Transport
 {
     const IPFAMILY_IPV4 = CURL_IPRESOLVE_V4;
@@ -21,7 +23,7 @@ class Transport
         $curlResponse = curl_exec($curl);
         $total = microtime(true) - $start;
         if ($curlResponse === false) {
-            throw new Error(sprintf(
+            throw new CurlError(sprintf(
                 'Curl error [errno: %d, url: %s, time: %.3fs): %s',
                 curl_errno($curl),
                 $request->getUrl(),


### PR DESCRIPTION
We are currently just using Error, which makes it hard to catch this particular error without also catching 404s, 500s, etc.